### PR TITLE
Remove Currency::Zero, add summing utility function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["money", "currency"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/arcanyx-pub/cashmoney-rs"
-version = "0.4.1"
+version = "0.5.0"
 
 [dependencies]
 rust_decimal = "1.36.0"

--- a/src/currency.rs
+++ b/src/currency.rs
@@ -3,10 +3,6 @@ use crate::Error;
 /// Supported currencies, identified by their ISO 4217 code.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Currency {
-    // Only valid when `amount` is 0. Used when constructing the default value for Money. Can be
-    // added to or subtracted from any other currency, and can be divided or multiplied (which will
-    // of course result in a zero value).
-    Zero,
     // United States Dollar
     USD,
     // Canadian Dollar
@@ -16,22 +12,16 @@ pub enum Currency {
 impl Currency {
     pub fn max_precision(&self) -> u32 {
         match self {
-            Currency::Zero => 0,
             Currency::USD => 2,
             Currency::CAD => 2,
         }
     }
 }
 
-/// Returns the result of operating on two currencies. Generally, they should be the same, or else
-/// a MismatchedCurrency error is returned. The `Zero` Currency is an exception; it takes on the
-/// currency of the other operand.
+/// Returns the result of operating on two currencies. They should be the same, or else
+/// a MismatchedCurrency error is returned.
 pub fn combine_currency(lhs: Currency, rhs: Currency) -> Result<Currency, Error> {
     let currency = if lhs == rhs {
-        lhs
-    } else if lhs == Currency::Zero {
-        rhs
-    } else if rhs == Currency::Zero {
         lhs
     } else {
         return Err(Error::MismatchedCurrency);
@@ -58,27 +48,6 @@ mod tests {
     fn combine_currency__difference__returns_error() -> Result<()> {
         let e = expect_err!(combine_currency(Currency::USD, Currency::CAD));
         expect_eq!(e, Error::MismatchedCurrency);
-        Ok(())
-    }
-
-    #[test]
-    fn combine_currency__zero_and_zero__returns_zero() -> Result<()> {
-        let combined = expect_ok!(combine_currency(Currency::Zero, Currency::Zero));
-        expect_eq!(combined, Currency::Zero);
-        Ok(())
-    }
-
-    #[test]
-    fn combine_currency__zero_and_usd__returns_usd() -> Result<()> {
-        let combined = expect_ok!(combine_currency(Currency::Zero, Currency::USD));
-        expect_eq!(combined, Currency::USD);
-        Ok(())
-    }
-
-    #[test]
-    fn combine_currency__usd_and_zero__returns_usd() -> Result<()> {
-        let combined = expect_ok!(combine_currency(Currency::USD, Currency::Zero));
-        expect_eq!(combined, Currency::USD);
         Ok(())
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,10 +8,6 @@ pub enum Error {
     InvalidMoneyValue(String),
     /// A mathematical operation was attempted on monetary values of different currencies.
     MismatchedCurrency,
-    /// `Money::new` was called with `Currency::Zero`. You should specify a real currency instead.
-    /// If you really want to create a zero-valued Money with `Zero` currency, use
-    /// `Money::default()` instead.
-    ZeroCurrencyUsedUnnecessarily,
 }
 
 impl fmt::Display for Error {
@@ -24,12 +20,6 @@ impl fmt::Display for Error {
                 write!(
                     f,
                     "A mathematical operation was attempted on values of different currencies"
-                )
-            }
-            Self::ZeroCurrencyUsedUnnecessarily => {
-                write!(
-                    f,
-                    "`Money::new` cannot be called with `Currency::Zero`. Use `Money::default()` instead."
                 )
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod error;
 mod fractional_money;
 mod macros;
 mod money;
+pub mod util;
 
 pub use crate::currency::Currency;
 pub use crate::error::Error;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,14 +16,6 @@ macro_rules! cad {
     }};
 }
 
-/// Creates 0-valued money with the special `Zero` currency.
-#[macro_export]
-macro_rules! zero {
-    () => {{
-        $crate::Money::default()
-    }};
-}
-
 #[cfg(test)]
 #[allow(non_snake_case)]
 mod tests {
@@ -76,13 +68,5 @@ mod tests {
     #[should_panic]
     fn cad__3_decimals__panics() {
         cad!(0.123);
-    }
-
-    #[test]
-    fn zero() -> Result<()> {
-        let z = zero!();
-        expect_eq!(z.amount(), dec!(0));
-        expect_eq!(z.currency(), Currency::Zero);
-        Ok(())
     }
 }

--- a/src/money.rs
+++ b/src/money.rs
@@ -4,12 +4,11 @@ use crate::fractional_money::FractionalMoney;
 use rust_decimal::Decimal;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
-use std::iter;
 use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 /// A monetary value in a certain currency with a valid denomination, e.g., 13.37 USD but not
 /// 1.337 USD.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Money {
     /// The validated and normalized FractionalMoney based on `currency`.
     money: FractionalMoney,
@@ -125,13 +124,6 @@ impl Neg for Money {
     }
 }
 
-/// If the iterator is empty, then the special `Zero` currency will be the result.
-impl iter::Sum for Money {
-    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.fold(Default::default(), Add::add)
-    }
-}
-
 impl Ord for Money {
     fn cmp(&self, other: &Self) -> Ordering {
         self.money.cmp(&other.money)
@@ -146,7 +138,6 @@ impl PartialOrd for Money {
 
 fn validate_and_normalize(amt: Decimal, currency: Currency) -> Result<Decimal, Error> {
     match currency {
-        Currency::Zero => Err(Error::ZeroCurrencyUsedUnnecessarily),
         Currency::USD | Currency::CAD => {
             let scale = amt.scale();
             // We don't allow scale=1 since it is unconventional and likely indicates the calling

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,76 @@
+use crate::{Currency, Error, Money};
+use rust_decimal_macros::dec;
+
+/// Attempts to compute the sum of `moneys`, which must all match `currency` or else a
+/// `MismatchedCurrency` error is thrown. If `moneys` is empty, then a zero-valued `Money` of the
+/// given `currency` is returned.
+pub fn try_sum(moneys: &[Money], currency: Currency) -> Result<Money, Error> {
+    let default = Money::new(dec!(0), currency)?;
+
+    moneys
+        .iter()
+        .try_fold(default, |acc, x| Money::try_add(&acc, x))
+}
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use super::*;
+    use crate::{cad, usd};
+    use anyhow::Result;
+    use expecting::*;
+
+    #[test]
+    fn try_sum__empty() -> Result<()> {
+        let moneys: Vec<Money> = vec![];
+
+        let sum = expect_ok!(try_sum(&moneys, Currency::CAD));
+        expect_eq!(sum, cad!(0));
+        Ok(())
+    }
+
+    #[test]
+    fn try_sum__one_item() -> Result<()> {
+        let moneys: Vec<Money> = vec![cad!(9.99)];
+
+        let sum = expect_ok!(try_sum(&moneys, Currency::CAD));
+        expect_eq!(sum, cad!(9.99));
+        Ok(())
+    }
+
+    #[test]
+    fn try_sum__one_item__wrong_currency() -> Result<()> {
+        let moneys: Vec<Money> = vec![cad!(9.99)];
+
+        let err = expect_err!(try_sum(&moneys, Currency::USD));
+        expect_eq!(err, Error::MismatchedCurrency);
+        Ok(())
+    }
+
+    #[test]
+    fn try_sum__two_items() -> Result<()> {
+        let moneys: Vec<Money> = vec![cad!(9.99), cad!(0.01)];
+
+        let sum = expect_ok!(try_sum(&moneys, Currency::CAD));
+        expect_eq!(sum, cad!(10));
+        Ok(())
+    }
+
+    #[test]
+    fn try_sum__two_items__wrong_currency() -> Result<()> {
+        let moneys: Vec<Money> = vec![cad!(9.99), cad!(0.01)];
+
+        let err = expect_err!(try_sum(&moneys, Currency::USD));
+        expect_eq!(err, Error::MismatchedCurrency);
+        Ok(())
+    }
+
+    #[test]
+    fn try_sum__two_items__different_currency() -> Result<()> {
+        let moneys: Vec<Money> = vec![cad!(9.99), usd!(0.01)];
+
+        let err = expect_err!(try_sum(&moneys, Currency::CAD));
+        expect_eq!(err, Error::MismatchedCurrency);
+        Ok(())
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use cashmoney::util::try_sum;
 use cashmoney::{cad, usd, Currency, Money};
 use expecting::*;
 use rust_decimal_macros::dec;
@@ -52,10 +53,10 @@ fn money_ops() -> Result<()> {
     expect_eq!(a, usd!(-2));
     expect_eq!(-a, usd!(2));
 
-    // let v: Vec<Money> = vec![usd!(1), usd!(2), usd!(0.99)];
-    // let sum: Money = v.into_iter().sum();
-    //
-    // expect_eq!(sum.amount(), dec!(3.99));
-    // expect_eq!(sum.currency(), Currency::USD);
+    let v: Vec<Money> = vec![usd!(1), usd!(2), usd!(0.99)];
+    let sum = expect_ok!(try_sum(&v, Currency::USD));
+
+    expect_eq!(sum.amount(), dec!(3.99));
+    expect_eq!(sum.currency(), Currency::USD);
     Ok(())
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -52,35 +52,10 @@ fn money_ops() -> Result<()> {
     expect_eq!(a, usd!(-2));
     expect_eq!(-a, usd!(2));
 
-    let v: Vec<Money> = vec![usd!(1), usd!(2), usd!(0.99)];
-    let sum: Money = v.into_iter().sum();
-
-    expect_eq!(sum.amount(), dec!(3.99));
-    expect_eq!(sum.currency(), Currency::USD);
-    Ok(())
-}
-
-#[test]
-fn special_zero_currency() -> Result<()> {
-    let mut a = Money::default();
-    expect_eq!(a.currency(), Currency::Zero);
-    expect_eq!(a.amount(), dec!(0));
-    expect_eq!((a * dec!(2)).round(), Money::default());
-
-    a += cad!(9.99);
-    expect_eq!(a, cad!(9.99));
-
-    a += Money::default();
-    expect_eq!(a, cad!(9.99));
-
-    let b = a * dec!(2);
-    expect_eq!(b.round(), cad!(19.98));
-
-    let v: Vec<Money> = vec![];
-    let sum: Money = v.into_iter().sum();
-
-    expect_eq!(sum.amount(), dec!(0));
-    expect_eq!(sum.currency(), Currency::Zero);
-
+    // let v: Vec<Money> = vec![usd!(1), usd!(2), usd!(0.99)];
+    // let sum: Money = v.into_iter().sum();
+    //
+    // expect_eq!(sum.amount(), dec!(3.99));
+    // expect_eq!(sum.currency(), Currency::USD);
     Ok(())
 }


### PR DESCRIPTION
It seemed like a good idea to create a special "Zero" currency to enable summing of Money objects with standard Rust traits, but in retrospect, it just makes both the library and calling code more complex and error-prone. This PR removes the Zero currency, requiring that all Money objects have a real currency. As a compromise, it provides a new utility function for summing Money objects.